### PR TITLE
Added delete units functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # monPlanR
-monPlanR is a test project, investigating the use of React to implement the current monplan project that is in development. 
+monPlanR is a test project, investigating the use of React to implement the current monplan project that is in development.
 
 ## Get started
 Currently the system is using npm for the ES6 transpiling and run scripts. To start the project first install dependencies:
@@ -9,8 +9,14 @@ npm install
 then to run development environment:
 ```
 npm run dev
-``` 
+```
 Optionally if you wish to build a production distrubution to test on a server or for whatever reason you can build a dist via:
 ```
 npm run production
+```
+
+## Test
+To test the code for any syntaxical errors or warnings, as well as quality code testing:
+```
+npm test
 ```

--- a/app/components/CourseStructure.jsx
+++ b/app/components/CourseStructure.jsx
@@ -1,22 +1,56 @@
 import * as React from "react";
-import {Table} from "semantic-ui-react";
-import TeachingPeriod from "./TeachingPeriod.jsx"
+import {Container, Label, Table} from "semantic-ui-react";
+import TeachingPeriod from "./TeachingPeriod.jsx";
 
 class CourseStructure extends React.Component {
+    constructor() {
+        super();
+        this.state = {"teachingPeriods":[{"year":2016,"type":"S1-01","numberOfUnits":4,"units":["FIT1008","FIT1013","FIT1047","FIT1045"]},{"year":2016,"type":"S2-02","numberOfUnits":4,"units":["FIT1008","FIT2004","FIT1049","MTH1035"]},{"year":2017,"type":"S1-01","numberOfUnits":4,"units":[null,null,null,null]},{"year":2017,"type":"S2-02","numberOfUnits":4,"units":["FIT1049",null,null,null]},{"year":2018,"type":"S1-01","numberOfUnits":4,"units":[null,null,null,null]},{"year":2018,"type":"S2-02","numberOfUnits":4,"units":[null,null,null,null]},{"year":2019,"type":"S1-01","numberOfUnits":4,"units":[null,null,null,null]},{"year":2019,"type":"S2-02","numberOfUnits":4,"units":[null,null,null,null]},{"year":2020,"type":"S1-01","numberOfUnits":4,"units":[null,null,null,null]}]};
+    }
+    deleteUnit(teachingPeriodIndex, unitIndex) {
+        const updatedTeachingPeriods = this.state.teachingPeriods;
+        updatedTeachingPeriods[teachingPeriodIndex].units[unitIndex] = undefined;
+        this.setState({
+            teachingPeriods: updatedTeachingPeriods
+        });
+    }
     render() {
+        const teachingPeriodsEle = this.state.teachingPeriods.map((teachingPeriod, index) => {
+            return <TeachingPeriod
+                        key={`${teachingPeriod.year}-${teachingPeriod.type}`}
+                        index={index}
+                        year={teachingPeriod.year}
+                        classification={teachingPeriod.type}
+                        numberOfUnits={teachingPeriod.numberOfUnits}
+                        deleteUnit={this.deleteUnit.bind(this)}
+                        units={teachingPeriod.units} />
+        });
+
         return (
-            <Table celled fixed>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.HeaderCell>Teaching Period</Table.HeaderCell>
-                        <Table.HeaderCell>Unit</Table.HeaderCell>
-                        <Table.HeaderCell>Unit</Table.HeaderCell>
-                        <Table.HeaderCell>Unit</Table.HeaderCell>
-                        <Table.HeaderCell>Unit</Table.HeaderCell>
-                    </Table.Row>
-                    <Table.Body></Table.Body>
-                </Table.Header>
-            </Table>
+            <Container>
+                <Label color="green" size="large">
+                    Total Credits Earnt
+                    <Label.Detail id="credits">0</Label.Detail>
+                </Label>
+                <Label color="green" size="large">
+                    Total Expenses
+                    <Label.Detail id="expenses">$0</Label.Detail>
+                </Label>
+                <Table celled fixed>
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell>Teaching Period</Table.HeaderCell>
+                            <Table.HeaderCell>Unit</Table.HeaderCell>
+                            <Table.HeaderCell>Unit</Table.HeaderCell>
+                            <Table.HeaderCell>Unit</Table.HeaderCell>
+                            <Table.HeaderCell>Unit</Table.HeaderCell>
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {teachingPeriodsEle}
+                    </Table.Body>
+                </Table>
+            </Container>
         );
     }
 }

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -1,17 +1,18 @@
-import React from "react";
+import React, {Component} from "react";
+import {Container, Segment} from "semantic-ui-react";
 
-class Footer extends React.Component {
+class Footer extends Component {
     render () {
         return (
-            <div className="ui inverted fixed bottom vertical footer stackable segment">
-            <div className="ui center aligned container">
+            <Segment inverted attached="bottom" className="footer stackable">
+                <Container textAlign="center">
                     <h4 className="ui inverted header">monPlan</h4>
                     <p>A Monash University Course Planner, designed by Monash Students, for Monash Students.</p>
                     <p>This project is licensed under <strong>the MIT License</strong> by monPlan</p>
                     <p>Copyright &copy; monPlan 2016 | Copyright &copy; Monash University 2016</p>
                     <img className="logo" src="resources/img/monash.png" alt="logo" />
-                </div>
-            </div>
+                </Container>
+            </Segment>
         );
     }
 }

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -19,12 +19,6 @@ class Header extends Component {
                     monPlan Alpha
                 </Menu.Header>
                 <UnitSearch className="item" />
-                <Menu.Item id="creditCounter">
-                    <Label color="green" size="large">
-                        Total Credits Earnt
-                        <Label.Detail id="credits">0</Label.Detail>
-                    </Label>
-                </Menu.Item>
                 <Menu.Menu position="right">
                     <Popup
                         id="displayMessage"
@@ -32,7 +26,7 @@ class Header extends Component {
                         header="Everything looks good"
                         content="As you add units, we will inform you of any conflicts, such as missing prerequisites."
                         />
-                    <Dropdown icon="info" className="item">
+                    <Dropdown floating icon="info" className="item">
                         <Dropdown.Menu>
                             <Dropdown.Header>Quick Links (for Devs)</Dropdown.Header>
                             <Dropdown.Item as="a" href="https://github.com/MonashUnitPlanner" target="_blank"><Icon name="github" />GitHub Project</Dropdown.Item>

--- a/app/components/Plan.jsx
+++ b/app/components/Plan.jsx
@@ -1,9 +1,19 @@
 import React, {Component} from "react";
+import {Container, Grid} from "semantic-ui-react";
+
 import CourseStructure from "./CourseStructure.jsx";
 
 class Plan extends Component {
     render() {
-        return <CourseStructure />;
+        return (
+            <Container className="main text">
+                <Grid>
+                    <Grid.Row>
+                        <CourseStructure />
+                    </Grid.Row>
+                </Grid>
+            </Container>
+        );
     }
 }
 

--- a/app/components/TeachingPeriod.jsx
+++ b/app/components/TeachingPeriod.jsx
@@ -1,19 +1,48 @@
 import * as React from "react";
-import {Table} from "semantic-ui-react";
+import {Dropdown, Table} from "semantic-ui-react";
 import Unit from "./Unit.jsx";
 
-class TeachingPeriod extends React.Component {
-    render() {
-        var units = [<Unit></Unit>];
-        return (
-            <Table.Row>
-                <Table.Cell class="teachingPeriod cell" data-popup-id={this.props.popupId}>
-                    {this.props.teachingPeriodString}
-                </Table.Cell>
-                {units}
-            </Table.Row>
-        );
-    }
+/**
+ * TeachingPeriod component
+ *
+ * Common teaching periods: semester one, semester two, summer semester A,
+ * summer semester B, winter semester
+ *
+ * @function
+ * @arg props
+ */
+function TeachingPeriod(props) {
+    const deleteUnit = unitIndex => {
+        props.deleteUnit(props.index, unitIndex);
+    };
+
+    const unitsEle = props.units.map((unit, index) => {
+        if(!unit) {
+            return <Unit
+                key={`${props.year}-${props.classification}-${index}`}
+                index={index}
+                free={true} />;
+        }
+        return <Unit key={`${props.year}-${props.classification}-${unit}`}
+                     index={index}
+                     deleteUnit={deleteUnit}
+                     free={false}
+                     code={unit} />;
+    });
+
+    return (
+        <Table.Row>
+            <Table.Cell className="teachingPeriod cell">
+                {props.year}-{props.classification}
+                <Dropdown icon="setting">
+                    <Dropdown.Menu>
+                        <Dropdown.Item text="Remove" />
+                    </Dropdown.Menu>
+                </Dropdown>
+            </Table.Cell>
+            {unitsEle}
+        </Table.Row>
+    );
 }
 
 export default TeachingPeriod;

--- a/app/components/Unit.jsx
+++ b/app/components/Unit.jsx
@@ -1,10 +1,42 @@
 import React from "react";
-import {Table} from "semantic-ui-react";
+import {Button, Dropdown, Table} from "semantic-ui-react";
 
-class Unit extends React.Component {
-    render() {
+/**
+ * Unit component
+ *
+ * @function Unit
+ * @extends React.Component
+ */
+function Unit(props) {
+    /**
+     * Shows unit details in a modal.
+     */
+    const handleDetail = () => {
+
+    };
+
+    /**
+     * Removes unit from the course structure.
+     */
+    const handleDelete = () => {
+        if(props.free) {
+            return;
+        }
+
+        props.deleteUnit(props.index);
+    };
+
+    return (
         <Table.Cell>
-            {this.props.code}
+            {props.code}
+            {!props.free &&
+                <Button.Group size="tiny">
+                    <Button basic onClick={handleDetail} color="blue" icon="info" />
+                    <Button basic onClick={handleDelete} color="red" icon="close" />
+                </Button.Group>
+            }
         </Table.Cell>
-    }
+    );
 }
+
+export default Unit;

--- a/app/components/UnitSearch.jsx
+++ b/app/components/UnitSearch.jsx
@@ -71,6 +71,7 @@ export default class UnitSearch extends Component {
                 onSearchChange={this.handleSearchChange}
                 results={results}
                 value={value}
+                placeholder="Add Unit"
                 {...this.props}
                 />
         );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,21 @@
-var HtmlWebpackPlugin = require('html-webpack-plugin')
+var HtmlWebpackPlugin = require("html-webpack-plugin");
 
 var HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
-    template: __dirname + '/app/index.html',
-    filename: 'index.html',
-    inject: 'body'
-})
+    template: __dirname + "/app/index.html",
+    filename: "index.html",
+    inject: "body"
+});
 
 module.exports = {
     entry: [
-        './app/index.jsx'
+        "./app/index.jsx"
     ],
 
+    devtool: "eval-source-map",
+
     output: {
-        path: __dirname + '/dist',
-        filename: 'bundle.js'
+        path: __dirname + "/dist",
+        filename: "bundle.js"
     },
 
     module: {
@@ -25,4 +27,4 @@ module.exports = {
     },
 
     plugins: [HtmlWebpackPluginConfig]
-}
+};


### PR DESCRIPTION
This will be the last pull request that does not follow the practices outlined in this project.

- `/plan` now displays a course structure specified from a JSON object (hard coded for now, will soon use local storage to fetch existing serialised course structure if any)
- Buttons in units to view details or remove units
- Can now delete units from the course structure
- Elements rewritten to use semantic-ui React components
- Reduced number of eslint warnings and errors
- minor text fixes