### PR TITLE
Updating Unit detail view functionality

### DIFF
--- a/app/components/CollapseButton.jsx
+++ b/app/components/CollapseButton.jsx
@@ -4,13 +4,13 @@ import { Grid, Icon, Button } from "semantic-ui-react";
 function CollapseButton(props){
     if(props.collapse){
         return(
-            <Button floated="right" onClick={props.onCollapseClick}>
+            <Button compact={true} onClick={props.onCollapseClick}>
                     Show unit details <Icon name="chevron down" />
             </Button>
         );
     } else {
         return (
-            <Button floated="right" onClick={props.onCollapseClick}>
+            <Button compact={true} onClick={props.onCollapseClick}>
                     Hide unit details <Icon name="chevron up" />
             </Button>
         );

--- a/app/components/CollapseButton.jsx
+++ b/app/components/CollapseButton.jsx
@@ -4,13 +4,13 @@ import { Grid, Icon, Button } from "semantic-ui-react";
 function CollapseButton(props){
     if(props.collapse){
         return(
-            <Button compact={true} onClick={props.onCollapseClick}>
+            <Button disabled={props.isDisabled} compact={true} onClick={props.onCollapseClick}>
                     Show unit details <Icon name="chevron down" />
             </Button>
         );
     } else {
         return (
-            <Button compact={true} onClick={props.onCollapseClick}>
+            <Button disabled={props.isDisabled} compact={true} onClick={props.onCollapseClick}>
                     Hide unit details <Icon name="chevron up" />
             </Button>
         );

--- a/app/components/CollapseButton.jsx
+++ b/app/components/CollapseButton.jsx
@@ -19,7 +19,8 @@ function CollapseButton(props){
 
 CollapseButton.propTypes = {
     onCollapseClick: PropTypes.func.isRequired,
-    collapse: PropTypes.bool.isRequired
+    collapse: PropTypes.bool.isRequired,
+    isDisabled: PropTypes.bool.isRequired
 };
 
 export default CollapseButton;

--- a/app/components/Unit/UnitInfo.jsx
+++ b/app/components/Unit/UnitInfo.jsx
@@ -68,7 +68,8 @@ UnitInfo.propTypes = {
     Faculty: PropTypes.string.isRequired,
     Synopsis: PropTypes.string.isRequired,
     usefulnessScore: PropTypes.number.isRequired,
-    likeScore: PropTypes.number.isRequired
+    likeScore: PropTypes.number.isRequired,
+    isDisabled: PropTypes.bool.isRequired
 };
 
 export default UnitInfo;

--- a/app/components/Unit/UnitInfo.jsx
+++ b/app/components/Unit/UnitInfo.jsx
@@ -43,9 +43,6 @@ function UnitInfo(props) {
 
                         <Grid.Column width={4}>
                         <Grid.Row>
-
-                        </Grid.Row>
-                        <Grid.Row>
                             <SetuRating starRating={props.usefulnessScore} heartRating={props.likeScore} />
                         </Grid.Row>
 

--- a/app/components/Unit/UnitInfo.jsx
+++ b/app/components/Unit/UnitInfo.jsx
@@ -33,6 +33,7 @@ function UnitInfo(props) {
                         <Grid.Column width={12}>
                             <Grid.Row>
                                     <h3>{props.UnitCode + " - " + props.UnitName}</h3>
+                                    <p>{props.Faculty}</p>
                                     <hr />
                                     <p>{props.Synopsis}</p>
                                     <a target="blank" href={"https://unitguidemanager.monash.edu/view?unitCode=" + props.UnitCode + "&tpCode=S1-01&tpYear=2016"}>View unit guide for this unit</a>

--- a/app/components/Unit/UnitInfo.jsx
+++ b/app/components/Unit/UnitInfo.jsx
@@ -65,6 +65,7 @@ UnitInfo.propTypes = {
     onCollapseClick: PropTypes.func.isRequired,
     UnitCode: PropTypes.string.isRequired,
     UnitName: PropTypes.string.isRequired,
+    Faculty: PropTypes.string.isRequired,
     Synopsis: PropTypes.string.isRequired,
     usefulnessScore: PropTypes.number.isRequired,
     likeScore: PropTypes.number.isRequired

--- a/app/components/Unit/UnitInfo.jsx
+++ b/app/components/Unit/UnitInfo.jsx
@@ -9,6 +9,7 @@ function UnitInfo(props) {
         return (
              <div className="ui raised segment">
                 <CollapseButton
+                    isDisabled={props.isDisabled}
                     collapse={props.collapse}
                     onCollapseClick={props.onCollapseClick} />
             </div>
@@ -18,6 +19,7 @@ function UnitInfo(props) {
             return (
                 <div className="ui raised segment">
                    <CollapseButton
+                        isDisabled={props.isDisabled}
                         collapse={props.collapse}
                         onCollapseClick={props.onCollapseClick} />
                    <UnitInfoPlaceholder />
@@ -27,6 +29,7 @@ function UnitInfo(props) {
             return (
                 <div className="ui raised segment">
                    <CollapseButton
+                        isDisabled={props.isDisabled}
                         collapse={props.collapse}
                         onCollapseClick={props.onCollapseClick} />
                     <Grid celled stackable columns={2}>

--- a/app/components/Unit/UnitInfoPlaceholder.jsx
+++ b/app/components/Unit/UnitInfoPlaceholder.jsx
@@ -6,10 +6,12 @@ import CollapseButton from "../CollapseButton.jsx";
 
 function UnitInfoPlaceholder(props) {
     return (
-        <Grid celled>
+        <Grid celled stackable columns={2}>
             <Grid.Column width={12}>
                 <Grid.Row>
                     <Image src='../resources/img/loaders/header.png' />
+                    <br />
+                    <Image src='../resources/img/loaders/smallText.png' />
                     <Loader active size="huge"></Loader>
                     <hr />
                     <Image src='../resources/img/loaders/short-paragraph.png' />

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -21,7 +21,7 @@ class UnitInfoContainer extends Component {
         super(props);
         this.state = {
             collapse: true,
-            isLoading: true,
+            isLoading: false,
             UnitCode: "",
             UnitName: "",
             Faculty: "Faculty of IT",
@@ -30,7 +30,6 @@ class UnitInfoContainer extends Component {
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
         this.unitSelected = this.unitSelected.bind(this);
-        this.componentDidMount = this.componentDidMount.bind(this);
     }
 
     handleCollapseClick() {
@@ -38,17 +37,6 @@ class UnitInfoContainer extends Component {
         this.setState({
             collapse: newState
         });
-    }
-
-    componentDidMount(){
-        
-        setTimeout(function(){
-            this.setState({
-                isLoading: false
-            });
-        }.bind(this)
-        ,1000);
-        
     }
 
     unitSelected(nUnitCode){

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -25,7 +25,8 @@ class UnitInfoContainer extends Component {
             UnitCode: "",
             UnitName: "",
             Faculty: "Faculty of IT",
-            Synopsis: ""
+            Synopsis: "",
+            isFirstSearch: true
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
         this.unitSelected = this.unitSelected.bind(this);
@@ -54,7 +55,8 @@ class UnitInfoContainer extends Component {
         
         this.setState({
             isLoading: true,
-            collapse: false
+            collapse: false,
+            isFirstSearch: false
         });
 
         UnitQuery.getExtendedUnitData(nUnitCode)
@@ -82,6 +84,7 @@ class UnitInfoContainer extends Component {
                 <br />
                 <UnitSearch onResult={this.unitSelected} />
                 <UnitInfo
+                    isDisabled={this.state.isFirstSearch}
                     UnitCode={this.state.UnitCode}
                     UnitName={this.state.UnitName}
                     Faculty={this.state.Faculty}

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -59,7 +59,8 @@ class UnitInfoContainer extends Component {
             isFirstSearch: false
         });
 
-        UnitQuery.getExtendedUnitData(nUnitCode)
+        setTimeout(function(){
+            UnitQuery.getExtendedUnitData(nUnitCode)
             .then(function(response) {
                 let source = response.data;
                 const re = new RegExp(_.escapeRegExp(nUnitCode), "i");
@@ -76,6 +77,10 @@ class UnitInfoContainer extends Component {
             .catch(function(error) {
                 console.log(error);
             });
+        }.bind(this)
+        ,300);
+
+        
     }
 
     render() {

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -24,6 +24,7 @@ class UnitInfoContainer extends Component {
             isLoading: true,
             UnitCode: "",
             UnitName: "",
+            Faculty: "Faculty of IT",
             Synopsis: ""
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
@@ -66,6 +67,7 @@ class UnitInfoContainer extends Component {
                     isLoading: false,
                     UnitCode: match.UnitCode,
                     UnitName: match.UnitName,
+                    Faculty: match.Faculty,
                     Synopsis: match.Sypnosis
                 });
             }.bind(this))
@@ -82,6 +84,7 @@ class UnitInfoContainer extends Component {
                 <UnitInfo
                     UnitCode={this.state.UnitCode}
                     UnitName={this.state.UnitName}
+                    Faculty={this.state.Faculty}
                     Synopsis={this.state.Synopsis}
                     usefulnessScore={testData.usefulnessScore}
                     likeScore={testData.likeScore}


### PR DESCRIPTION
A series of updates to the unit detail view related components:

+ added faculty name to the details 
+ updated proptypes to validate any new props added
+ updated loading placeholder to be stackable and to also have a bar for faculty name
+ made the detail view button disabled before user selects first unit 
----
- removed unnecessary functions such as now redundant component will mount delay
----
c changed the button to no longer float so that it behaves better with stacking