### PR TITLE
[dev] Separated Unitinfo and unit search components -- READ NOTES FOR FULL DETAILS

### DIFF
--- a/app/components/CourseStatisticGroup.jsx
+++ b/app/components/CourseStatisticGroup.jsx
@@ -1,0 +1,52 @@
+import React, { PropTypes } from "react";
+import { Statistic, Label, Container } from "semantic-ui-react";
+
+/**
+ * 
+ */
+function CourseStatisticGroup(props) {
+
+
+    return (
+        <MediaQuery minDeviceWidth={768}>{(desktop) => {
+            if (desktop) {
+                
+                return (
+                    <Statistic.Group size="tiny">
+                        <Statistic>
+                            <Statistic.Value>
+                                <Icon name='student' />
+                                {props.currentCreditPoints}
+                            </Statistic.Value>
+                            <Statistic.Label>Credit Points</Statistic.Label>
+                        </Statistic>
+
+                        <Statistic>
+                            <Statistic.Value >
+                                <Icon name='dollar' />
+                                {props.currentEstCost}
+                            </Statistic.Value>
+                            <Statistic.Label>Total Est. Cost</Statistic.Label>
+                        </Statistic>
+                    </Statistic.Group>
+                );
+            } else {
+                return (
+                    <Container>
+                        <Label color="green" size="large">
+                            Total Credits Earnt
+                            <Label.Detail>{props.currentCreditPoints}</Label.Detail>
+                        </Label>
+                        <Label color="green" size="large">
+                            Total Expenses
+                            <Label.Detail>${props.currentEstCost}</Label.Detail>
+                        </Label>
+                    </Container>
+                );
+            }
+        }}
+        </MediaQuery>
+    );
+}
+
+export default CourseStatisticGroup

--- a/app/components/CourseStatisticGroup.jsx
+++ b/app/components/CourseStatisticGroup.jsx
@@ -2,10 +2,18 @@ import React, { PropTypes } from "react";
 import { Statistic, Label, Container } from "semantic-ui-react";
 
 /**
+ * This currently is a component that renders the statistics for cost and credit points
+ * @author JXNS
  * 
+ * @param {number} currentCreditPoints - A number representing the toal sum of credit points accumulated from a course
+ * @param {number} currentEstCost - A number representing the current total estimated cost of a degree
  */
 function CourseStatisticGroup(props) {
 
+    CourseStatisticGroup.propTypes = {
+        currentCreditPoints: PropTypes.number.isRequired,
+        currentEstCost: PropTypes.number.isRequired
+    };
 
     return (
         <MediaQuery minDeviceWidth={768}>{(desktop) => {
@@ -49,4 +57,4 @@ function CourseStatisticGroup(props) {
     );
 }
 
-export default CourseStatisticGroup
+export default CourseStatisticGroup;

--- a/app/components/CourseStructure.jsx
+++ b/app/components/CourseStructure.jsx
@@ -42,6 +42,9 @@ class CourseStructure extends Component {
         // Fetch common teaching periods to get names for each teaching period code.
         axios.get("/data/teachingPeriods/common.json")
              .then(response => {
+                 /**
+                  * Grabbing the common teaching periods and sorting
+                  */
                  function compareDate(a, b) {
                      return Math.sign(new Date(...a.split("/").reverse()) - new Date(...b.split("/").reverse()));
                  }

--- a/app/components/CourseStructure.jsx
+++ b/app/components/CourseStructure.jsx
@@ -552,10 +552,10 @@ class CourseStructure extends Component {
                     <Message>
                         <Button floated="right" onClick={this.props.doneAddingToCourse}>Cancel</Button>
                         <Message.Header>
-                            Adding {this.props.unitToAdd.code}
+                            Adding {this.props.unitToAdd.UnitCode}
                         </Message.Header>
                         <p>
-                            Select a table cell in your course structure to insert {this.props.unitToAdd.code}.
+                            Select a table cell in your course structure to insert {this.props.unitToAdd.UnitCode}.
                         </p>
                     </Message>
                 }
@@ -563,10 +563,10 @@ class CourseStructure extends Component {
                     <Message>
                         <Button floated="right" onClick={this.cancelMoving.bind(this)}>Cancel</Button>
                         <Message.Header>
-                            Moving {this.state.unitToBeMoved.code}
+                            Moving {this.state.unitToBeMoved.UnitCode}
                         </Message.Header>
                         <p>
-                            Select a table cell in your course structure to move {this.state.unitToBeMoved.code}.
+                            Select a table cell in your course structure to move {this.state.unitToBeMoved.UnitCode}.
                             Selecting a table cell where there is already an occupied unit will swap the units.
                         </p>
                     </Message>

--- a/app/components/TeachingPeriod/TeachingPeriod.jsx
+++ b/app/components/TeachingPeriod/TeachingPeriod.jsx
@@ -60,9 +60,9 @@ function TeachingPeriod(props) {
                      showMoveUnitUI={props.showMoveUnitUI}
                      swapUnit={swapUnit}
                      free={false}
-                     code={unit.code}
-                     name={unit.name}
-                     faculty={unit.faculty} />;
+                     code={unit.UnitCode}
+                     name={unit.UnitName}
+                     faculty={unit.Faculty} />;
     });
 
     const teachingPeriodData = props.data;

--- a/app/components/Unit/Unit.jsx
+++ b/app/components/Unit/Unit.jsx
@@ -83,7 +83,7 @@ class Unit extends React.Component {
             "Business and Economics": "teal",
             "Education": "violet",
             "Engineering": "orange",
-            "Information Technology": "purple",
+            "Information Techonology": "purple",
             "Law": "grey",
             "Medicine, Nursing and Health Sciences": "blue",
             "Pharmacy and Pharmaceutical Sciences": "olive",

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -23,6 +23,9 @@ class Plan extends Component {
             unitToAdd: undefined,
             showAddToCourseUI: false
         };
+
+        this.addToCourse = this.addToCourse.bind(this);
+        this.doneAddingToCourse = this.doneAddingToCourse.bind(this);
     }
 
     /**
@@ -55,10 +58,11 @@ class Plan extends Component {
             <div>
                 <Container className="move">
                 
-                    <UnitInfoContainer unitSelected={this.state.unitToAdd} />
+                    <UnitInfoContainer 
+                        unitSelected={this.state.unitToAdd} />
 
                     <Grid reversed="mobile" stackable>
-                        <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>
+                        <Grid.Column width="9"><UnitSearchContainer onResult={this.addToCourse} /></Grid.Column>
                         <Grid.Column width="3" />
                         <Grid.Column width="4">
                         <a target="_blank" href="https://docs.google.com/a/monash.edu/forms/d/e/1FAIpQLScyXYUi_4-C7juCSrsvxqBuQCf1rKpoJLb7fVknxxApfrym2g/viewform">
@@ -87,8 +91,8 @@ class Plan extends Component {
                 <Container className="main text">
                     <CourseStructure startYear={parseInt(startYear)}
                                      endYear={parseInt(endYear)}
-                                     addToCourse={this.addToCourse.bind(this)}
-                                     doneAddingToCourse={this.doneAddingToCourse.bind(this)}
+                                     addToCourse={this.addToCourse}
+                                     doneAddingToCourse={this.doneAddingToCourse}
                                      unitToAdd={this.state.unitToAdd} />
                 </Container>
             </div>

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -54,6 +54,7 @@ class Plan extends Component {
             <div>
                 <UnitInfoContainer addToCourse={this.addToCourse.bind(this)}
                                    doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
+                
                 <Container className="main text">
                     <CourseStructure startYear={parseInt(startYear)}
                                      endYear={parseInt(endYear)}
@@ -62,6 +63,85 @@ class Plan extends Component {
                                      unitToAdd={this.state.unitToAdd} />
                 </Container>
             </div>
+
+            <Container className="move">
+                
+                <UnitInfo
+                    isDisabled={this.state.isFirstSearch}
+                    UnitCode={this.state.UnitCode}
+                    UnitName={this.state.UnitName}
+                    Faculty={this.state.Faculty}
+                    Synopsis={this.state.Synopsis}
+                    usefulnessScore={5}
+                    likeScore={3}
+                    collapse={this.state.collapse}
+                    isLoading={this.state.isLoading}
+                    onCollapseClick={this.handleCollapseClick}
+                    error={this.state.error}
+                />
+
+                <Grid reversed="mobile" stackable>
+                    <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>
+                    <Grid.Column width="3" />
+                    <Grid.Column width="4">
+                    <a target="_blank" href="https://docs.google.com/a/monash.edu/forms/d/e/1FAIpQLScyXYUi_4-C7juCSrsvxqBuQCf1rKpoJLb7fVknxxApfrym2g/viewform">
+                        <Button primary fluid>Give us feedback</Button>
+                    </a>
+                    </Grid.Column>
+                </Grid>
+                
+                {false &&
+                <Grid stackable>
+                    <Grid.Row>
+                        <Grid.Column width={2}>
+                            
+                        </Grid.Column>
+                        <Grid.Column width={8} />
+                        <Grid.Column width={6}>
+                            {false /* disable rendering status information for now */ && 
+                            <MediaQuery minDeviceWidth={768}>{(desktop) => {
+                                if (desktop) {
+                                    return(
+                                        <Statistic.Group size="tiny">
+                                            <Statistic>
+                                                <Statistic.Value>
+                                                    <Icon name='student' />
+                                                    {this.state.currentCreditPoints}
+                                                </Statistic.Value>
+                                                <Statistic.Label>Credit Points</Statistic.Label>
+                                            </Statistic>
+
+                                            <Statistic>
+                                                <Statistic.Value >
+                                                    <Icon name='dollar' />
+                                                    {this.state.currentEstCost}
+                                                </Statistic.Value>
+                                                <Statistic.Label>Total Est. Cost</Statistic.Label>
+                                            </Statistic>
+                                        </Statistic.Group>
+                                    );
+                                } else {
+                                    return (
+                                      <Container>
+                                          <Label color="green" size="large">
+                                              Total Credits Earnt
+                                              <Label.Detail>{this.state.currentCreditPoints}</Label.Detail>
+                                          </Label>
+                                          <Label color="green" size="large">
+                                              Total Expenses
+                                              <Label.Detail>${this.state.currentEstCost}</Label.Detail>
+                                          </Label>
+                                      </Container>
+                                    );
+                                }
+                            }}
+                            </MediaQuery>
+                            }
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+                }
+            </Container>
 
         );
     }

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -2,6 +2,7 @@ import React, {Component} from "react";
 import {Container} from "semantic-ui-react";
 
 import CourseStructure from "../CourseStructure.jsx";
+import CourseStatisticGroup from "../CourseStatisticGroup.jsx";
 import UnitSearchContainer from "../../containers/UnitSearchContainer.jsx";
 import UnitInfoContainer from "../../containers/UnitInfoContainer.jsx";
 
@@ -99,43 +100,7 @@ class Plan extends Component {
                         <Grid.Column width={8} />
                         <Grid.Column width={6}>
                             {false /* disable rendering status information for now */ && 
-                            <MediaQuery minDeviceWidth={768}>{(desktop) => {
-                                if (desktop) {
-                                    return(
-                                        <Statistic.Group size="tiny">
-                                            <Statistic>
-                                                <Statistic.Value>
-                                                    <Icon name='student' />
-                                                    {this.state.currentCreditPoints}
-                                                </Statistic.Value>
-                                                <Statistic.Label>Credit Points</Statistic.Label>
-                                            </Statistic>
-
-                                            <Statistic>
-                                                <Statistic.Value >
-                                                    <Icon name='dollar' />
-                                                    {this.state.currentEstCost}
-                                                </Statistic.Value>
-                                                <Statistic.Label>Total Est. Cost</Statistic.Label>
-                                            </Statistic>
-                                        </Statistic.Group>
-                                    );
-                                } else {
-                                    return (
-                                      <Container>
-                                          <Label color="green" size="large">
-                                              Total Credits Earnt
-                                              <Label.Detail>{this.state.currentCreditPoints}</Label.Detail>
-                                          </Label>
-                                          <Label color="green" size="large">
-                                              Total Expenses
-                                              <Label.Detail>${this.state.currentEstCost}</Label.Detail>
-                                          </Label>
-                                      </Container>
-                                    );
-                                }
-                            }}
-                            </MediaQuery>
+                                <CourseStatisticGroup />
                             }
                         </Grid.Column>
                     </Grid.Row>

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from "react";
 import {Container, Grid, Button} from "semantic-ui-react";
 
+import UnitQuery from "../../utils/UnitQuery";
 import CourseStructure from "../CourseStructure.jsx";
 import CourseStatisticGroup from "../CourseStatisticGroup.jsx";
 import UnitSearchContainer from "../../containers/UnitSearchContainer.jsx";
@@ -34,8 +35,23 @@ class Plan extends Component {
      *
      * @param {string} unitToAdd - The unit to be added.
      */
-    addToCourse(unitToAdd) {
-        this.setState({ unitToAdd });
+    addToCourse(nUnitCode) {
+        if(!(nUnitCode === undefined)) {
+
+            UnitQuery.getExtendedUnitData(nUnitCode)
+                .then(function(response) {
+                    let data = response.data;
+                    console.log(data);
+
+                    this.setState({
+                        unitToAdd: data
+                    });
+                    
+                }.bind(this))
+                .catch(function(error) {
+                    console.log(error);
+                });
+        }
     }
 
     /**
@@ -59,7 +75,7 @@ class Plan extends Component {
                 <Container className="move">
                 
                     <UnitInfoContainer 
-                        unitSelected={this.state.unitToAdd} />
+                        newUnit={this.state.unitToAdd} />
 
                     <Grid reversed="mobile" stackable>
                         <Grid.Column width="9"><UnitSearchContainer onResult={this.addToCourse} /></Grid.Column>
@@ -73,6 +89,7 @@ class Plan extends Component {
                     
                     {false &&
                     <Grid stackable>
+
                         <Grid.Row>
                             <Grid.Column width={2}>
                                 

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -53,8 +53,37 @@ class Plan extends Component {
 
         return (
             <div>
-                <UnitInfoContainer addToCourse={this.addToCourse.bind(this)}
-                                   doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
+                <Container className="move">
+                
+                    <UnitInfoContainer addToCourse={this.addToCourse.bind(this)}
+                                    doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
+
+                    <Grid reversed="mobile" stackable>
+                        <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>
+                        <Grid.Column width="3" />
+                        <Grid.Column width="4">
+                        <a target="_blank" href="https://docs.google.com/a/monash.edu/forms/d/e/1FAIpQLScyXYUi_4-C7juCSrsvxqBuQCf1rKpoJLb7fVknxxApfrym2g/viewform">
+                            <Button primary fluid>Give us feedback</Button>
+                        </a>
+                        </Grid.Column>
+                    </Grid>
+                    
+                    {false &&
+                    <Grid stackable>
+                        <Grid.Row>
+                            <Grid.Column width={2}>
+                                
+                            </Grid.Column>
+                            <Grid.Column width={8} />
+                            <Grid.Column width={6}>
+                                {false /* disable rendering status information for now */ && 
+                                    <CourseStatisticGroup />
+                                }
+                            </Grid.Column>
+                        </Grid.Row>
+                    </Grid>
+                    }
+                </Container>
                 
                 <Container className="main text">
                     <CourseStructure startYear={parseInt(startYear)}
@@ -64,50 +93,6 @@ class Plan extends Component {
                                      unitToAdd={this.state.unitToAdd} />
                 </Container>
             </div>
-
-            <Container className="move">
-                
-                <UnitInfo
-                    isDisabled={this.state.isFirstSearch}
-                    UnitCode={this.state.UnitCode}
-                    UnitName={this.state.UnitName}
-                    Faculty={this.state.Faculty}
-                    Synopsis={this.state.Synopsis}
-                    usefulnessScore={5}
-                    likeScore={3}
-                    collapse={this.state.collapse}
-                    isLoading={this.state.isLoading}
-                    onCollapseClick={this.handleCollapseClick}
-                    error={this.state.error}
-                />
-
-                <Grid reversed="mobile" stackable>
-                    <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>
-                    <Grid.Column width="3" />
-                    <Grid.Column width="4">
-                    <a target="_blank" href="https://docs.google.com/a/monash.edu/forms/d/e/1FAIpQLScyXYUi_4-C7juCSrsvxqBuQCf1rKpoJLb7fVknxxApfrym2g/viewform">
-                        <Button primary fluid>Give us feedback</Button>
-                    </a>
-                    </Grid.Column>
-                </Grid>
-                
-                {false &&
-                <Grid stackable>
-                    <Grid.Row>
-                        <Grid.Column width={2}>
-                            
-                        </Grid.Column>
-                        <Grid.Column width={8} />
-                        <Grid.Column width={6}>
-                            {false /* disable rendering status information for now */ && 
-                                <CourseStatisticGroup />
-                            }
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
-                }
-            </Container>
-
         );
     }
 }

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -55,8 +55,7 @@ class Plan extends Component {
             <div>
                 <Container className="move">
                 
-                    <UnitInfoContainer addToCourse={this.addToCourse.bind(this)}
-                                       doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
+                    <UnitInfoContainer unitSelected={this.state.unitToAdd} />
 
                     <Grid reversed="mobile" stackable>
                         <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>

--- a/app/components/base/Plan.jsx
+++ b/app/components/base/Plan.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {Container} from "semantic-ui-react";
+import {Container, Grid, Button} from "semantic-ui-react";
 
 import CourseStructure from "../CourseStructure.jsx";
 import CourseStatisticGroup from "../CourseStatisticGroup.jsx";
@@ -56,7 +56,7 @@ class Plan extends Component {
                 <Container className="move">
                 
                     <UnitInfoContainer addToCourse={this.addToCourse.bind(this)}
-                                    doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
+                                       doneAddingToCourse={this.doneAddingToCourse.bind(this)} />
 
                     <Grid reversed="mobile" stackable>
                         <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -58,7 +58,7 @@ class UnitInfoContainer extends Component {
         
         
         if(!(nextProps.newUnit === undefined)) {
-            let nUnitCode = nextProps.newUnit.UnitCode
+            let nUnitCode = nextProps.newUnit.UnitCode;
             
             if(this.state.isFirstSearch) {
                 this.setState({collapse: false});

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -33,6 +33,7 @@ class UnitInfoContainer extends Component {
             currentEstCost: 0,
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
+        this.handleAddToCourse = this.handleAddToCourse.bind(this);
     }
 
     /**
@@ -91,6 +92,14 @@ class UnitInfoContainer extends Component {
                     });
                 }.bind(this));
         }
+    }
+
+    handleAddToCourse() {
+        this.props.addToCourse({
+            code: this.state.UnitCode,
+            name: this.state.UnitName,
+            faculty: this.state.Faculty
+        });
     }
 
     /**

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -112,84 +112,19 @@ class UnitInfoContainer extends Component {
      */
     render() {
         return (
-            <Container className="move">
-                
-                <UnitInfo
-                    isDisabled={this.state.isFirstSearch}
-                    UnitCode={this.state.UnitCode}
-                    UnitName={this.state.UnitName}
-                    Faculty={this.state.Faculty}
-                    Synopsis={this.state.Synopsis}
-                    usefulnessScore={5}
-                    likeScore={3}
-                    collapse={this.state.collapse}
-                    isLoading={this.state.isLoading}
-                    onCollapseClick={this.handleCollapseClick}
-                    error={this.state.error}
+            <UnitInfo
+                isDisabled={this.state.isFirstSearch}
+                UnitCode={this.state.UnitCode}
+                UnitName={this.state.UnitName}
+                Faculty={this.state.Faculty}
+                Synopsis={this.state.Synopsis}
+                usefulnessScore={5}
+                likeScore={3}
+                collapse={this.state.collapse}
+                isLoading={this.state.isLoading}
+                onCollapseClick={this.handleCollapseClick}
+                error={this.state.error}
                 />
-
-                <Grid reversed="mobile" stackable>
-                    <Grid.Column width="9"><UnitSearchContainer onResult={this.unitSelected} /></Grid.Column>
-                    <Grid.Column width="3" />
-                    <Grid.Column width="4">
-                    <a target="_blank" href="https://docs.google.com/a/monash.edu/forms/d/e/1FAIpQLScyXYUi_4-C7juCSrsvxqBuQCf1rKpoJLb7fVknxxApfrym2g/viewform">
-                        <Button primary fluid>Give us feedback</Button>
-                    </a>
-                    </Grid.Column>
-                </Grid>
-                
-                {false &&
-                <Grid stackable>
-                    <Grid.Row>
-                        <Grid.Column width={2}>
-                            
-                        </Grid.Column>
-                        <Grid.Column width={8} />
-                        <Grid.Column width={6}>
-                            {false /* disable rendering status information for now */ && 
-                            <MediaQuery minDeviceWidth={768}>{(desktop) => {
-                                if (desktop) {
-                                    return(
-                                        <Statistic.Group size="tiny">
-                                            <Statistic>
-                                                <Statistic.Value>
-                                                    <Icon name='student' />
-                                                    {this.state.currentCreditPoints}
-                                                </Statistic.Value>
-                                                <Statistic.Label>Credit Points</Statistic.Label>
-                                            </Statistic>
-
-                                            <Statistic>
-                                                <Statistic.Value >
-                                                    <Icon name='dollar' />
-                                                    {this.state.currentEstCost}
-                                                </Statistic.Value>
-                                                <Statistic.Label>Total Est. Cost</Statistic.Label>
-                                            </Statistic>
-                                        </Statistic.Group>
-                                    );
-                                } else {
-                                    return (
-                                      <Container>
-                                          <Label color="green" size="large">
-                                              Total Credits Earnt
-                                              <Label.Detail>{this.state.currentCreditPoints}</Label.Detail>
-                                          </Label>
-                                          <Label color="green" size="large">
-                                              Total Expenses
-                                              <Label.Detail>${this.state.currentEstCost}</Label.Detail>
-                                          </Label>
-                                      </Container>
-                                    );
-                                }
-                            }}
-                            </MediaQuery>
-                            }
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
-                }
-            </Container>
         );
     }
 }

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -81,11 +81,7 @@ class UnitInfoContainer extends Component {
                         error: false
                     });
 
-                    this.props.addToCourse({
-                        code: nUnitCode,
-                        name: data.UnitName,
-                        faculty: data.Faculty
-                    });
+                    this.props.addToCourse(data);
                     
                 }.bind(this))
                 .catch(function(error) {

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -33,7 +33,6 @@ class UnitInfoContainer extends Component {
             currentEstCost: 0,
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
-        this.unitSelected = this.unitSelected.bind(this);
     }
 
     /**
@@ -48,33 +47,21 @@ class UnitInfoContainer extends Component {
         });
     }
 
-    /**
-     * @author Saurabh Joshi
-     */
-    handleAddToCourse() {
-        this.props.addToCourse({
-            code: this.state.UnitCode,
-            name: this.state.UnitName,
-            faculty: this.state.Faculty
-        });
-    }
 
     /**
      * The unitSelected function is called whenever a new unit is selected.
      * @author JXNS
      * @param {string} nUnitCode - the new unit code selected by the child component, this code is used as the query param for the api call.
      */
-    componentDidUpdate() {
+    componentWillReceiveProps(nextProps) {
         
-        let nUnitCode = this.props.unitSelected
+        let nUnitCode = nextProps.unitSelected
         
-        if(!(this.props.unitSelected === undefined)) {
+        if(!(nUnitCode === undefined)) {
             
             if(this.state.isFirstSearch) {
                 this.setState({collapse: false});
             }
-
-            this.handleAddToCourse.bind(this);
 
             this.setState({
                 isLoading: true,
@@ -94,11 +81,6 @@ class UnitInfoContainer extends Component {
                         error: false
                     });
 
-                    this.props.addToCourse({
-                        code: nUnitCode,
-                        name: data.UnitName,
-                        faculty: data.Faculty
-                    });
                 }.bind(this))
                 .catch(function(error) {
                     console.log(error);

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -64,46 +64,51 @@ class UnitInfoContainer extends Component {
      * @author JXNS
      * @param {string} nUnitCode - the new unit code selected by the child component, this code is used as the query param for the api call.
      */
-    unitSelected(nUnitCode) {
-        if(this.state.isFirstSearch) {
-            this.setState({collapse: false});
+    componentDidUpdate() {
+        
+        let nUnitCode = this.props.unitSelected
+        
+        if(!(this.props.unitSelected === undefined)) {
+            
+            if(this.state.isFirstSearch) {
+                this.setState({collapse: false});
+            }
+
+            this.handleAddToCourse.bind(this);
+
+            this.setState({
+                isLoading: true,
+                isFirstSearch: false
+            });
+
+            UnitQuery.getExtendedUnitData(nUnitCode)
+                .then(function(response) {
+                    let data = response.data;
+
+                    this.setState({
+                        isLoading: false,
+                        UnitCode: nUnitCode,
+                        UnitName: data.UnitName,
+                        Faculty: data.Faculty,
+                        Synopsis: data.Description,
+                        error: false
+                    });
+
+                    this.props.addToCourse({
+                        code: nUnitCode,
+                        name: data.UnitName,
+                        faculty: data.Faculty
+                    });
+                }.bind(this))
+                .catch(function(error) {
+                    console.log(error);
+                    this.setState({
+                        isLoading: false,
+                        UnitCode: nUnitCode,
+                        error: true,
+                    });
+                }.bind(this));
         }
-
-        this.handleAddToCourse.bind(this);
-
-        this.setState({
-            isLoading: true,
-            isFirstSearch: false
-        });
-
-        UnitQuery.getExtendedUnitData(nUnitCode)
-            .then(function(response) {
-                let data = response.data;
-
-                this.setState({
-                    isLoading: false,
-                    UnitCode: nUnitCode,
-                    UnitName: data.UnitName,
-                    Faculty: data.Faculty,
-                    Synopsis: data.Description,
-                    error: false
-                });
-
-                this.props.addToCourse({
-                    code: nUnitCode,
-                    name: data.UnitName,
-			        faculty: data.Faculty
-                });
-            }.bind(this))
-            .catch(function(error) {
-                console.log(error);
-                this.setState({
-                    isLoading: false,
-                    UnitCode: nUnitCode,
-                    error: true,
-                });
-            }.bind(this));
-
     }
 
     /**
@@ -124,7 +129,7 @@ class UnitInfoContainer extends Component {
                 isLoading={this.state.isLoading}
                 onCollapseClick={this.handleCollapseClick}
                 error={this.state.error}
-                />
+            />
         );
     }
 }

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -33,7 +33,6 @@ class UnitInfoContainer extends Component {
             currentEstCost: 0,
         };
         this.handleCollapseClick = this.handleCollapseClick.bind(this);
-        this.handleAddToCourse = this.handleAddToCourse.bind(this);
     }
 
     /**
@@ -82,6 +81,12 @@ class UnitInfoContainer extends Component {
                         error: false
                     });
 
+                    this.props.addToCourse({
+                        code: nUnitCode,
+                        name: data.UnitName,
+                        faculty: data.Faculty
+                    });
+                    
                 }.bind(this))
                 .catch(function(error) {
                     console.log(error);
@@ -93,14 +98,7 @@ class UnitInfoContainer extends Component {
                 }.bind(this));
         }
     }
-
-    handleAddToCourse() {
-        this.props.addToCourse({
-            code: this.state.UnitCode,
-            name: this.state.UnitName,
-            faculty: this.state.Faculty
-        });
-    }
+    
 
     /**
      * The component currently returns both the unitsearch and unitInfo components with all the gathered state.

--- a/app/containers/UnitInfoContainer.jsx
+++ b/app/containers/UnitInfoContainer.jsx
@@ -55,9 +55,10 @@ class UnitInfoContainer extends Component {
      */
     componentWillReceiveProps(nextProps) {
         
-        let nUnitCode = nextProps.unitSelected
         
-        if(!(nUnitCode === undefined)) {
+        
+        if(!(nextProps.newUnit === undefined)) {
+            let nUnitCode = nextProps.newUnit.UnitCode
             
             if(this.state.isFirstSearch) {
                 this.setState({collapse: false});
@@ -80,8 +81,6 @@ class UnitInfoContainer extends Component {
                         Synopsis: data.Description,
                         error: false
                     });
-
-                    this.props.addToCourse(data);
                     
                 }.bind(this))
                 .catch(function(error) {


### PR DESCRIPTION
- changed code architecture to be cleaner, now unit info and unit search are separated and are instead brought together by the Plan component
- Now the plan component makes an API call and feeds that data as needed
- Currently there is a bad repeat where the UnitInfoContainer makes the API call again even though the data has already been fetched by parent. Will need to fix this.
- There is an issue in the API where "Faculty of Information Technology" is returning a string with Technology misspelt as "Techonology". This causes issues with the colouring  of IT units which I have fixed.
- Also seperated the statistics group into a seperate component