### PR TITLE
[CRE] [fix] [dep] Better validation engine

### DIFF
--- a/app/actions/CourseActions.js
+++ b/app/actions/CourseActions.js
@@ -11,6 +11,12 @@ export const insertTeachingPeriod = (index, year, code) => {
             year,
             code
         });
+
+        dispatch(validateCourse());
+        dispatch({
+            type: "MODIFIED_COURSE_PLAN"
+        });
+
         dispatch({
             type: "GET_NEXT_SEMESTER_STRING"
         });
@@ -26,6 +32,11 @@ export const removeTeachingPeriod = (index, units) => {
             type: "REMOVE_TEACHING_PERIOD",
             index,
             units
+        });
+
+        dispatch(validateCourse());
+        dispatch({
+            type: "MODIFIED_COURSE_PLAN"
         });
 
         dispatch({
@@ -46,6 +57,11 @@ export const addTeachingPeriod = (teachingPeriods, startYear, teachingPeriodData
             type: "APPEND_TEACHING_PERIOD",
             year,
             code
+        });
+
+        dispatch(validateCourse());
+        dispatch({
+            type: "MODIFIED_COURSE_PLAN"
         });
 
         dispatch({

--- a/app/utils/rules.pegjs
+++ b/app/utils/rules.pegjs
@@ -8,11 +8,11 @@ start
 	= expression
 
 expression
-	= left:and_expr _ "or" _ right:and_expr { return {type: "OR", left: left, right: right} }
+	= left:and_expr _ "OR"i _ _? right:and_expr { return {type: "OR", left: left, right: right} }
     / and_expr
 
 and_expr
-	= left:bracket_expr _ "AND" _ _ right:bracket_expr { return {type: "AND", left: left, right: right } }
+	= left:bracket_expr _ "AND"i _ _? right:bracket_expr { return {type: "AND", left: left, right: right } }
     / bracket_expr
 
 bracket_expr
@@ -20,37 +20,62 @@ bracket_expr
     / for
 
 for
-	= "For COURSE_CODE IN " list:list " Do " do_branch:string " Otherwise " otherwise_branch:string { return {type: "FOR", variable: "COURSE_CODE", list: list, do: do_branch, otherwise: otherwise_branch } }
+	= "For COURSE_CODE IN " list:list " Do " do_branch:expression " Otherwise " otherwise_branch:expression { return {type: "FOR", variable: "COURSE_CODE", list: list, do: do_branch, otherwise: otherwise_branch } }
     / string
 
 list
-	= "{" list:[a-zA-Z0-9"-"]*  "}" { return list.join("").split(", ") }
+	= "{" list:[a-zA-Z0-9-, "%\.]*  "}" { return list.join("").split(", ") }
 
 string "string"
 	= minCreditPoints
     / permissionRequired
     / passedUnits
+	/ coreqUnits
+	/ enrolledInCourse
+	/ incompatibleWith
+	/ previouslyCoded
     / true
     / ""
 
 minCreditPoints
-	= "Must have passed " digits:[0-9]+ " credit points" { return {type: "MIN_CREDIT_POINTS", minCreditPoints: parseInt(digits.join(""))} }
+	= "Must have passed " digits:[0-9]+ " (I/W)"? " credit points" unitsOwnedBy:unitsOwnedBy? { return {type: "MIN_CREDIT_POINTS", minCreditPoints: parseInt(digits.join("")), unitsOwnedBy: unitsOwnedBy} }
 
 permissionRequired
 	= "Permission required" { return "PERMISSION_REQUIRED" }
 
 passedUnits
-	= "Must have passed " number:integer " (I/W)"? " unit" "s"? " in " list:list grades? { return { type: "PASSED_UNITS", number: number, list: list } }
+	= "Must have passed " number:integer " (I/W)"? " unit" "s"? " in " list:list grades:grades? { return { type: "PASSED_UNITS", number: number, list: list, grades: grades } }
+
+coreqUnits
+	= "Any passed co-req" " (I/W)"? " unit in " list:list { return { type: "PASSED_COREQ_UNITS", list: list }}
+	/ "Any co-req" " (I/W)"? " unit in " list:list { return { type: "COREQ_UNITS", list: list }}
+	/ "Any co-req unit set " list:list { return { type: "COREQ_UNIT_SET", list: list } }
+	/ "Any " number:integer " (I/W)"? " co-req units in " list:list { return { type: "PASSED_COREQ_UNITS", list: list, number: number }}
+
+enrolledInCourse
+	 = "Must be enrolled in course type " list:list { return { type: "ENROLLED_IN_COURSE_TYPE", list: list} }
+	 / "Must be enrolled in course version " list:list { return { type: "ENROLLED_IN_COURSE_VERSION", list: list } }
+	 / "Must be enrolled in course owned by " list:list { return { type: "ENROLLED_IN_COURSE_OWNED_BY", list: list } }
 
 grades
 	= " with grades other than " list
 
+unitsOwnedBy
+	= " from units owned by " list:list { return list }
+
 true
 	= "true" { return true }
 
+incompatibleWith
+	= "Incompatible with" " achievement in"? " (I/W)"? " " list:list { return { type: "INCOMPATIBLE_WITH", list: list } }
+
+previouslyCoded
+	= "Unit was previously coded " list:list { return { type: "PREVIOUSLY_CODED", list: list }}
+
 integer
-	= [0-9]+
+	= digits:[0-9]+ { return parseInt(digits.join(""), 10) }
     / "an" { return 1 }
+	/ "a" { return 1 }
 
 _ "whitespace"
 	= [ \t\n\r]*

--- a/app/utils/rules.pegjs
+++ b/app/utils/rules.pegjs
@@ -1,0 +1,56 @@
+/**
+ * This is a parsing expression grammar for rules, using PEG.js as the library.
+ * This constructs a parse tree, which can be traversed and be used as validation
+ * in ValidateCoursePlan.js.
+ */
+
+start
+	= expression
+
+expression
+	= left:and_expr _ "or" _ right:and_expr { return {type: "OR", left: left, right: right} }
+    / and_expr
+
+and_expr
+	= left:bracket_expr _ "AND" _ _ right:bracket_expr { return {type: "AND", left: left, right: right } }
+    / bracket_expr
+
+bracket_expr
+	= "(" expression:expression ")" { return expression }
+    / for
+
+for
+	= "For COURSE_CODE IN " list:list " Do " do_branch:string " Otherwise " otherwise_branch:string { return {type: "FOR", variable: "COURSE_CODE", list: list, do: do_branch, otherwise: otherwise_branch } }
+    / string
+
+list
+	= "{" list:[a-zA-Z0-9"-"]*  "}" { return list.join("").split(", ") }
+
+string "string"
+	= minCreditPoints
+    / permissionRequired
+    / passedUnits
+    / true
+    / ""
+
+minCreditPoints
+	= "Must have passed " digits:[0-9]+ " credit points" { return {type: "MIN_CREDIT_POINTS", minCreditPoints: parseInt(digits.join(""))} }
+
+permissionRequired
+	= "Permission required" { return "PERMISSION_REQUIRED" }
+
+passedUnits
+	= "Must have passed " number:integer " (I/W)"? " unit" "s"? " in " list:list grades? { return { type: "PASSED_UNITS", number: number, list: list } }
+
+grades
+	= " with grades other than " list
+
+true
+	= "true" { return true }
+
+integer
+	= [0-9]+
+    / "an" { return 1 }
+
+_ "whitespace"
+	= [ \t\n\r]*

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "nock": "^9.0.5",
     "nyc": "^10.1.2",
     "object-assign": "^4.1.1",
+    "pegjs": "^0.10.0",
+    "pegjs-loader": "^0.5.0",
     "react": "^15.3.2",
     "react-addons-css-transition-group": "^15.3.2",
     "react-addons-test-utils": "^15.4.2",

--- a/test/actionCreators/CourseActions.spec.js
+++ b/test/actionCreators/CourseActions.spec.js
@@ -21,6 +21,12 @@ describe("ACTION-CREATOR: CourseActions", () => {
                     code: "tpCode"
                 },
                 {
+                    type: "VALIDATE_COURSE"
+                },
+                {
+                    type: "MODIFIED_COURSE_PLAN"
+                },
+                {
                     type: "GET_NEXT_SEMESTER_STRING"
                 }
             ];
@@ -38,6 +44,12 @@ describe("ACTION-CREATOR: CourseActions", () => {
                     type: "REMOVE_TEACHING_PERIOD",
                     index: 1,
                     units: ["unit1", "unit2", "unit3", null],
+                },
+                {
+                    type: "VALIDATE_COURSE"
+                },
+                {
+                    type: "MODIFIED_COURSE_PLAN"
                 },
                 {
                     type: "GET_NEXT_SEMESTER_STRING"
@@ -279,6 +291,12 @@ describe("ACTION-CREATOR: CourseActions", () => {
             const mockUnits = [null, null, null, null, null];
             const expectedActions = [
                 {type: "REMOVE_TEACHING_PERIOD", index: 1, units: [null, null, null, null, null]},
+                {
+                    type: "VALIDATE_COURSE"
+                },
+                {
+                    type: "MODIFIED_COURSE_PLAN"
+                },
                 {type: "GET_NEXT_SEMESTER_STRING"}
             ];
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -3,16 +3,24 @@
  * importing Mocha and Chai's expect function, and injects it into the global
  * object. It also injects jsdom to simulate the browser environment so that
  * Enzyme mount can be used for testing complex React components.
+ *
+ * @author Saurabh Joshi, JXNS
  */
 
+import { describe, it } from "mocha";
+
 import chai from "chai";
-import expectSimple from "expect";
-import deepFreeze from "deep-freeze";
 import chaiEnzyme from "chai-enzyme";
 import sinonChai from "sinon-chai";
-import { describe, it } from "mocha";
+import expectSimple from "expect";
+
+import deepFreeze from "deep-freeze";
+
 import { jsdom } from "jsdom";
 import createMockRaf from "mock-raf";
+
+import fs from "fs";
+import peg from "pegjs";
 
 const exposedProperties = ["window", "navigator", "document"];
 
@@ -52,9 +60,10 @@ chai.use(sinonChai);
 global.describe = describe;
 global.it = it;
 global.expect = chai.expect;
-global.documentRef = document;
 global.MONPLAN_REMOTE_URL2 = "https://monplan-api-dev.appspot.com";
 global.MONPLAN_REMOTE_URL = "https://api2.monplan.tech";
+
+
 /**
  * The test function that will run for each Redux reducer action.
  *
@@ -70,4 +79,20 @@ global.test = (reducer, stateBefore, action, stateAfter) => {
     expectSimple(
         reducer(stateBefore, action)
     ).toEqual(stateAfter);
+};
+
+/**
+ * This is needed in order for Node to understand how to handle .pegjs files,
+ * which is used in parsing rules such as prereqs.
+ *
+ * Note: require.extensions is deprecated and should be replaced with something better
+ */
+require.extensions[".pegjs"] = function(module, filename) {
+    const source = fs.readFileSync(filename, "utf8");
+    const pegOptions = {
+        output: "source"
+    };
+
+    const output = `module.exports = ${peg.generate(source, pegOptions)};`;
+    return module._compile(output, filename);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,8 @@ const config = {
         loaders: [
             {test: /\.js$/, exclude: /node_modules/, loader: "babel-loader"},
             {test: /\.jsx$/, exclude: /node_modules/, loader: "babel-loader"},
-            {test: /\.css$/, loader: "style-loader!css-loader"}
+            {test: /\.css$/, loader: "style-loader!css-loader"},
+            {test: /\.pegjs$/, loader: "pegjs-loader"}
         ]
     },
 


### PR DESCRIPTION
Instead of using regular expressions to parse the rules, a library called PEG.js is used to parse the rules by specifying a grammar. By parsing the rules, it constructs a parse tree which can be traversed and be used for validating against the course plan.

It was annoying that mocha and babel-register parses non-JS files as JS files, so the current solution is to use `require.extensions` (which is a deprecated feature but it seems like Node won't get rid of it anytime soon) and use the PEG.js JavaScript API to compile it to JavaScript before sending it off to be compiled as a module. If there is a better way, then that would be great.

Please run `npm install` to install `pegjs pegjs-loader`.